### PR TITLE
Add | table pipeline step

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,10 @@ The search command starts a new search. It ignores all previous results and inst
 
 Shows the events that have the same source as the given event and which were close to the event in the log file. This is used when clicking "View context" on an event. This is useful if you are finding results from many different files and want to drill down into a specific file.
 
+#### `| table "<field1>,<field2>,..."`
+
+Creates a table containing the values of the specified fields.
+
 #### `| where <field1>=<value1> <field2>=<value2>...`
 
 The where command filters events by field value. The benefit of having this as a separate command instead of using the field=value syntax in the search command is that `| where` can act on fields that are extracted later in the pipeline, such as fields extracted by `| rex`.

--- a/internal/jobs/Job.go
+++ b/internal/jobs/Job.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/jackbister/logsuck/internal/events"
+	"github.com/jackbister/logsuck/internal/pipeline"
 )
 
 type JobState int32
@@ -34,6 +35,7 @@ type Job struct {
 	Query              string
 	StartTime, EndTime *time.Time
 	SortMode           events.SortMode
+	OutputType         pipeline.PipelinePipeType
 }
 
 type JobStats struct {

--- a/internal/jobs/JobRepository.go
+++ b/internal/jobs/JobRepository.go
@@ -18,17 +18,20 @@ import (
 	"time"
 
 	"github.com/jackbister/logsuck/internal/events"
+	"github.com/jackbister/logsuck/internal/pipeline"
 )
 
 type Repository interface {
 	AddResults(id int64, events []events.EventIdAndTimestamp) error
+	AddTableResults(id int64, tableRows []TableRow) error
 	AddFieldStats(id int64, fields []FieldStats) error
 	Get(id int64) (*Job, error)
 	GetResults(id int64, skip int, take int) (eventIds []int64, err error)
+	GetTableResults(id int64, skip int, take int) ([]TableRow, error)
 	GetFieldOccurences(id int64) (map[string]int, error)
 	GetFieldValues(id int64, fieldName string) (map[string]int, error)
 	GetNumMatchedEvents(id int64) (int64, error)
-	Insert(query string, startTime, endTime *time.Time, sortMode events.SortMode) (id *int64, err error)
+	Insert(query string, startTime, endTime *time.Time, sortMode events.SortMode, outputType pipeline.PipelinePipeType) (id *int64, err error)
 	UpdateState(id int64, state JobState) error
 }
 
@@ -36,4 +39,9 @@ type FieldStats struct {
 	Key         string
 	Value       string
 	Occurrences int
+}
+
+type TableRow struct {
+	RowNumber int
+	Values    map[string]string
 }

--- a/internal/parser/PipelineParser.go
+++ b/internal/parser/PipelineParser.go
@@ -52,6 +52,12 @@ func ParsePipeline(s string) (*PipelineParseResult, error) {
 			Args:     map[string]string{},
 			Value:    sb.String(),
 		})
+	} else {
+		steps = append(steps, ParsedPipelineStep{
+			StepType: "search",
+			Args:     map[string]string{},
+			Value:    "",
+		})
 	}
 
 	for len(p.tokens) > 0 {

--- a/internal/parser/PipelineParser_test.go
+++ b/internal/parser/PipelineParser_test.go
@@ -40,14 +40,14 @@ func TestExplicitSearch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ExplicitSearch parse returned error: %v", err)
 	}
-	if len(res.Steps) != 1 {
-		t.Fatalf("ExplicitSearch expected 1 step, got %v", len(res.Steps))
+	if len(res.Steps) != 2 {
+		t.Fatalf("ExplicitSearch expected 2 steps, got %v", len(res.Steps))
 	}
-	if res.Steps[0].StepType != "search" {
-		t.Fatalf("ExplicitSearch expected step 0 to be search, got %v", res.Steps[0].StepType)
+	if res.Steps[1].StepType != "search" {
+		t.Fatalf("ExplicitSearch expected step 1 to be search, got %v", res.Steps[0].StepType)
 	}
 	const expected = "source=*my-log.txt* hello world"
-	if expected != res.Steps[0].Value {
+	if expected != res.Steps[1].Value {
 		t.Fatalf("ExplicitSearch expected value='%v', got '%v'", expected, res.Steps[0].Value)
 	}
 }

--- a/internal/pipeline/RexPipelineStep.go
+++ b/internal/pipeline/RexPipelineStep.go
@@ -70,12 +70,16 @@ func (r *rexPipelineStep) Execute(ctx context.Context, pipe pipelinePipe, params
 	}
 }
 
-func (r *rexPipelineStep) IsGeneratorStep() bool {
-	return false
-}
-
 func (r *rexPipelineStep) Name() string {
 	return "rex"
+}
+
+func (r *rexPipelineStep) InputType() PipelinePipeType {
+	return PipelinePipeTypeEvents
+}
+
+func (r *rexPipelineStep) OutputType() PipelinePipeType {
+	return PipelinePipeTypeEvents
 }
 
 func compileRexStep(input string, options map[string]string) (pipelineStep, error) {

--- a/internal/pipeline/SearchPipelineStep.go
+++ b/internal/pipeline/SearchPipelineStep.go
@@ -90,12 +90,16 @@ func (s *searchPipelineStep) Execute(ctx context.Context, pipe pipelinePipe, par
 	}
 }
 
-func (s *searchPipelineStep) IsGeneratorStep() bool {
-	return true
-}
-
 func (s *searchPipelineStep) Name() string {
 	return "search"
+}
+
+func (r *searchPipelineStep) InputType() PipelinePipeType {
+	return PipelinePipeTypeNone
+}
+
+func (r *searchPipelineStep) OutputType() PipelinePipeType {
+	return PipelinePipeTypeEvents
 }
 
 func compileSearchStep(input string, options map[string]string) (pipelineStep, error) {

--- a/internal/pipeline/SurroundingPipelineStep.go
+++ b/internal/pipeline/SurroundingPipelineStep.go
@@ -78,12 +78,16 @@ func (s *surroundingPipelineStep) Execute(ctx context.Context, pipe pipelinePipe
 	}
 }
 
-func (s *surroundingPipelineStep) IsGeneratorStep() bool {
-	return true
-}
-
 func (s *surroundingPipelineStep) Name() string {
 	return "surrounding"
+}
+
+func (r *surroundingPipelineStep) InputType() PipelinePipeType {
+	return PipelinePipeTypeNone
+}
+
+func (r *surroundingPipelineStep) OutputType() PipelinePipeType {
+	return PipelinePipeTypeEvents
 }
 
 func compileSurroundingStep(input string, options map[string]string) (pipelineStep, error) {

--- a/internal/pipeline/TablePipelineStep.go
+++ b/internal/pipeline/TablePipelineStep.go
@@ -1,0 +1,68 @@
+// Copyright 2023 Jack Bister
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"context"
+	"strings"
+)
+
+type tablePipelineStep struct {
+	fields []string
+}
+
+func (s *tablePipelineStep) Execute(ctx context.Context, pipe pipelinePipe, params PipelineParameters) {
+	defer close(pipe.output)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case res, ok := <-pipe.input:
+			if !ok {
+				return
+			}
+			ret := make([]map[string]string, 0)
+			for _, evt := range res.Events {
+				m := map[string]string{}
+				for _, f := range s.fields {
+					m[f] = evt.Fields[f]
+				}
+				ret = append(ret, m)
+			}
+			res.TableRows = ret
+			pipe.output <- res
+		}
+	}
+}
+
+func (s *tablePipelineStep) Name() string {
+	return "table"
+}
+
+func (r *tablePipelineStep) InputType() PipelinePipeType {
+	return PipelinePipeTypeEvents
+}
+
+func (r *tablePipelineStep) OutputType() PipelinePipeType {
+	return PipelinePipeTypeTable
+}
+
+func compileTableStep(input string, options map[string]string) (pipelineStep, error) {
+	fields := strings.Split(input, ",")
+	return &tablePipelineStep{
+		fields: fields,
+	}, nil
+}

--- a/internal/pipeline/TablePipelineStep.go
+++ b/internal/pipeline/TablePipelineStep.go
@@ -62,7 +62,11 @@ func (r *tablePipelineStep) OutputType() PipelinePipeType {
 
 func compileTableStep(input string, options map[string]string) (pipelineStep, error) {
 	fields := strings.Split(input, ",")
+	trimmedFields := make([]string, len(fields))
+	for i, f := range fields {
+		trimmedFields[i] = strings.TrimSpace(f)
+	}
 	return &tablePipelineStep{
-		fields: fields,
+		fields: trimmedFields,
 	}, nil
 }

--- a/internal/pipeline/WherePipelineStep.go
+++ b/internal/pipeline/WherePipelineStep.go
@@ -55,12 +55,16 @@ func (s *wherePipelineStep) Execute(ctx context.Context, pipe pipelinePipe, para
 	}
 }
 
-func (s *wherePipelineStep) IsGeneratorStep() bool {
-	return false
-}
-
 func (s *wherePipelineStep) Name() string {
 	return "where"
+}
+
+func (r *wherePipelineStep) InputType() PipelinePipeType {
+	return PipelinePipeTypeEvents
+}
+
+func (r *wherePipelineStep) OutputType() PipelinePipeType {
+	return PipelinePipeTypeEvents
 }
 
 func compileWhereStep(input string, options map[string]string) (pipelineStep, error) {

--- a/internal/web/static/src/components/Autoform/Autoform.tsx
+++ b/internal/web/static/src/components/Autoform/Autoform.tsx
@@ -151,9 +151,6 @@ export function jsonSchemaToFormSpec(
         conditional: metadata.conditional,
       } as EnumFormField;
     }
-    if (metadata) {
-      console.log("md", metadata);
-    }
     return {
       type: "STRING",
       name,

--- a/internal/web/static/src/pages/SearchPage.tsx
+++ b/internal/web/static/src/pages/SearchPage.tsx
@@ -17,6 +17,7 @@
 import { Component, h } from "preact";
 import {
   FieldValueCounts,
+  JobResultResponse,
   JobState,
   PollJobResult,
   StartJobResult,
@@ -32,7 +33,8 @@ import { TopFieldValueInfo } from "../models/TopFieldValueInfo";
 import { RecentSearch } from "../services/RecentSearches";
 import { validateIsoTimestamp } from "../validateIsoTimestamp";
 import { LogsuckAppShell } from "../components/LogsuckAppShell";
-import { Alert, Button, Card, Pagination, Popover } from "@mantine/core";
+import { Alert, Button, Card, Pagination, Popover, Table } from "@mantine/core";
+import { JsonView } from "../components/JsonView/JsonView";
 
 const EVENTS_PER_PAGE = 25;
 const TOP_FIELDS_COUNT = 15;
@@ -47,7 +49,7 @@ interface SearchProps {
     jobId: number,
     skip: number,
     take: number
-  ) => Promise<LogEvent[]>;
+  ) => Promise<JobResultResponse>;
   abortJob: (jobId: number) => Promise<{}>;
   getFieldValueCounts: (
     jobId: number,
@@ -102,7 +104,7 @@ interface SearchedPolling extends SearchStateBase {
   jobId: number;
   poller: number;
 
-  searchResult: LogEvent[];
+  searchResult: JobResultResponse;
   numMatched: number;
 
   currentPageIndex: number;
@@ -118,7 +120,7 @@ interface SearchedPollingFinished extends SearchStateBase {
 
   jobId: number;
 
-  searchResult: LogEvent[];
+  searchResult: JobResultResponse;
   numMatched: number;
 
   currentPageIndex: number;
@@ -205,7 +207,10 @@ export class SearchPageComponent extends Component<
           state: SearchState.SEARCHED_POLLING,
           jobId: jobId,
           poller: window.setTimeout(async () => this.poll(jobId), 0),
-          searchResult: [],
+          searchResult: {
+            resultType: "EVENTS",
+            events: [],
+          },
           numMatched: 0,
           currentPageIndex: currentPageIndex,
         };
@@ -220,6 +225,7 @@ export class SearchPageComponent extends Component<
   }
 
   render() {
+    const resultLength = this.getResultLength();
     return (
       <LogsuckAppShell>
         <SearchInput
@@ -238,17 +244,17 @@ export class SearchPageComponent extends Component<
           )}
           {(this.state.state === SearchState.WAITING_FOR_SEARCH ||
             (this.state.state === SearchState.SEARCHED_POLLING &&
-              this.state.searchResult.length === 0)) && (
+              resultLength === 0)) && (
             <div>Loading... There should be a spinner here!</div>
           )}
           {((this.state.state === SearchState.SEARCHED_POLLING &&
-            this.state.searchResult.length > 0) ||
+            resultLength > 0) ||
             this.state.state === SearchState.SEARCHED_POLLING_FINISHED) && (
             <div>
-              {this.state.searchResult.length === 0 && (
+              {resultLength === 0 && (
                 <Alert>No results found. Try a different search?</Alert>
               )}
-              {this.state.searchResult.length !== 0 && (
+              {resultLength !== 0 && (
                 <div className="w-100 d-flex flex-row align-start gap-6">
                   <Popover
                     position="right"
@@ -299,12 +305,50 @@ export class SearchPageComponent extends Component<
                       </div>
                     </div>
                     <Card>
-                      <EventTable
-                        events={this.state.searchResult}
-                        onViewContextClicked={(id) =>
-                          this.onViewContextClicked(id)
-                        }
-                      />
+                      {this.state.searchResult.resultType === "EVENTS" && (
+                        <EventTable
+                          events={this.state.searchResult.events}
+                          onViewContextClicked={(id) =>
+                            this.onViewContextClicked(id)
+                          }
+                        />
+                      )}
+                      {this.state.searchResult.resultType === "TABLE" && (
+                        <div>
+                          <Table>
+                            <thead>
+                              <tr>
+                                {Object.keys(
+                                  this.state.searchResult.tableRows[0].values
+                                ).map((k) => (
+                                  <th style={{ paddingLeft: "28px" }}>{k}</th>
+                                ))}
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {this.state.searchResult.tableRows.map((tr) => (
+                                <tr key={tr.rowNumber}>
+                                  {Object.keys(tr.values).map((k) => (
+                                    <td key={k}>
+                                      <Button
+                                        variant="subtle"
+                                        onClick={() =>
+                                          this.addFieldQueryAndSearch(
+                                            k,
+                                            tr.values[k]
+                                          )
+                                        }
+                                      >
+                                        {tr.values[k]}
+                                      </Button>
+                                    </td>
+                                  ))}
+                                </tr>
+                              ))}
+                            </tbody>
+                          </Table>
+                        </div>
+                      )}
                     </Card>
                   </div>
                 </div>
@@ -399,13 +443,13 @@ export class SearchPageComponent extends Component<
       );
     }
     try {
-      const newEvents = await this.props.getResults(
+      const result = await this.props.getResults(
         this.state.jobId,
         newPageIndex * EVENTS_PER_PAGE,
         EVENTS_PER_PAGE
       );
       this.setState({
-        searchResult: newEvents,
+        searchResult: result,
         currentPageIndex: newPageIndex,
       });
       this.setQueryParams({
@@ -469,7 +513,10 @@ export class SearchPageComponent extends Component<
           async () => this.poll(startJobResult.id),
           500
         ),
-        searchResult: [],
+        searchResult: {
+          resultType: "EVENTS",
+          events: [],
+        },
         numMatched: 0,
         currentPageIndex: 0,
       });
@@ -541,15 +588,17 @@ export class SearchPageComponent extends Component<
       } else {
         nextState.poller = window.setTimeout(() => this.poll(id), 500);
       }
+      const resultLength = this.getResultLength();
       if (
-        this.state.searchResult.length < EVENTS_PER_PAGE &&
-        pollResult.stats.numMatchedEvents > this.state.searchResult.length
+        resultLength < EVENTS_PER_PAGE &&
+        pollResult.stats.numMatchedEvents > resultLength
       ) {
-        nextState.searchResult = await this.props.getResults(
+        const result = await this.props.getResults(
           id,
           this.state.currentPageIndex * EVENTS_PER_PAGE,
           EVENTS_PER_PAGE
         );
+        nextState.searchResult = result;
         if (id !== this.state.jobId) {
           return;
         }
@@ -558,5 +607,21 @@ export class SearchPageComponent extends Component<
     } catch (e) {
       console.log(e);
     }
+  }
+
+  private getResultLength(): number {
+    let resultLength = 0;
+    if (
+      this.state.state === SearchState.SEARCHED_POLLING ||
+      this.state.state === SearchState.SEARCHED_POLLING_FINISHED
+    ) {
+      console.log(this.state.searchResult);
+      if (this.state.searchResult.resultType === "EVENTS") {
+        resultLength = this.state.searchResult.events.length;
+      } else {
+        resultLength = this.state.searchResult.tableRows.length;
+      }
+    }
+    return resultLength;
   }
 }

--- a/internal/web/static/src/pages/SearchPage.tsx
+++ b/internal/web/static/src/pages/SearchPage.tsx
@@ -615,7 +615,6 @@ export class SearchPageComponent extends Component<
       this.state.state === SearchState.SEARCHED_POLLING ||
       this.state.state === SearchState.SEARCHED_POLLING_FINISHED
     ) {
-      console.log(this.state.searchResult);
       if (this.state.searchResult.resultType === "EVENTS") {
         resultLength = this.state.searchResult.events.length;
       } else {


### PR DESCRIPTION
This allows you to create a table from the fields in the results of a search.

It also lays the groundwork for future `| timechart` and `| stats` steps.